### PR TITLE
Address handle leaks in `GetSystem`

### DIFF
--- a/Koh/Helpers.cs
+++ b/Koh/Helpers.cs
@@ -176,6 +176,7 @@ namespace Koh
                 success = Interop.DuplicateToken(hToken, 2, ref hDupToken);
                 if (!success)
                 {
+                    CloseHandle(hToken);
                     Console.WriteLine("  [!] GetSystem() - DuplicateToken failed!");
                     return false;
                 }
@@ -183,6 +184,8 @@ namespace Koh
                 success = Interop.ImpersonateLoggedOnUser(hDupToken);
                 if (!success)
                 {
+                    CloseHandle(hToken);
+                    CloseHandle(hDupToken);
                     Console.WriteLine("  [!] GetSystem() - ImpersonateLoggedOnUser failed!");
                     return false;
                 }


### PR DESCRIPTION
`GetSystem` leaks token handles in error code paths.