### PR TITLE
Made CloseHandle available

### DIFF
--- a/Koh/Helpers.cs
+++ b/Koh/Helpers.cs
@@ -207,6 +207,11 @@ namespace Koh
             }
         }
 
+        private static void CloseHandle(IntPtr hToken)
+        {
+            throw new NotImplementedException();
+        }
+
         public static bool IsSystem()
         {
             // Returns true if the current context is "NT AUTHORITY\SYSTEM"


### PR DESCRIPTION
CloseHandle wasn't available after address leak patch 7ee54bbb5f2635a068e1af4b4207598bf49ce5d5 so the build was failing. This should fix it.